### PR TITLE
Adds `devcontainer.json` file for using GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,15 +20,20 @@
         "solrike.eclipse-theme-by-solrike"
       ],
       "settings": {
-				"workbench.iconTheme": "eclipse-theme-by-solrike",
-				"editor.bracketPairColorization.enabled": true,
+        "workbench.iconTheme": "eclipse-theme-by-solrike",
+        "editor.bracketPairColorization.enabled": true,
         "editor.experimental.StikyScroll.enabled": true,
-				"editor.minimap.scale": 2,
-				"editor.indentSize": "tabSize",
-				"editor.tabSize": 4,
-				"editor.renderWhitespace": "all",
-				"files.trimTrailingWhitespace": true
-			}
+        "editor.minimap.scale": 2,
+        "editor.indentSize": "tabSize",
+        "editor.tabSize": 4,
+        "editor.renderWhitespace": "all",
+        "files.trimTrailingWhitespace": true
+      }
+    },
+    "codespaces": {
+      "openFiles": [
+        "src/HelloWorld.java"
+      ]
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,6 @@
   "image": "mcr.microsoft.com/devcontainers/universal:2", // Default Image
   "customizations": {
     "vscode": {
-      // VS Code Extensions to be installed while the machine is being setup
       "extensions": [
         // Java Extension Pack
         "vscjava.vscode-java-pack",
@@ -10,6 +9,8 @@
         "VisualStudioExptTeam.vscodeintellicode",
         // Eclipse-styled themes
         "arzg.eclipse",
+        "solrike.eclipse-theme-by-solrike",
+        "eamodio.gitlens"
       ]
     },
     "codespaces": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,6 +22,7 @@
       "settings": {
 				"workbench.iconTheme": "eclipse-theme-by-solrike",
 				"editor.bracketPairColorization.enabled": true,
+        "editor.experimental.StikyScroll.enabled": true,
 				"editor.minimap.scale": 2,
 				"editor.indentSize": "tabSize",
 				"editor.tabSize": 4,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,20 +10,7 @@
         "VisualStudioExptTeam.vscodeintellicode",
         // Eclipse-styled themes
         "arzg.eclipse",
-        "solrike.eclipse-theme-by-solrike"
-      ],
-      // Workspace settings (can be customised by the user afterwards too)
-      "settings": {
-        "workbench.iconTheme": "eclipse-theme-by-solrike", // Eclipse Icon style
-        "workbench.colorTheme": "Eclipse Light",           // Eclipse-styled app
-        "editor.bracketPairColorization.enabled": true,    // Colors each bracket pair
-        "editor.experimental.StikyScroll.enabled": true,   // To stick all the functions, classes at the top
-        "editor.minimap.scale": 2,                         // Mini Map
-        "editor.indentSize": "tabSize",                    // Tab Indent
-        "editor.tabSize": 4,                               // Tab Size of 4
-        "editor.renderWhitespace": "all",                  // Shows the whitespaces
-        "files.trimTrailingWhitespace": true               // Removes any trailing whitespaces at the end
-      }
+      ]
     },
     "codespaces": {
       // Opens the Java file after the Codespace is built

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "latest",
+      "jdkDistro": "oracle",
+      "installGradle": true,
+      "installMaven": true,
+      "installAnt": true
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,5 +8,26 @@
       "installMaven": true,
       "installAnt": true
     }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Java Extension Pack
+        "vscjava.vscode-java-pack",
+        // Miscellaneous Extensions
+        "VisualStudioExptTeam.vscodeintellicode",
+        // Eclipse-styled theme
+        "solrike.eclipse-theme-by-solrike"
+      ],
+      "settings": {
+				"workbench.iconTheme": "eclipse-theme-by-solrike",
+				"editor.bracketPairColorization.enabled": true,
+				"editor.minimap.scale": 2,
+				"editor.indentSize": "tabSize",
+				"editor.tabSize": 4,
+				"editor.renderWhitespace": "all",
+				"files.trimTrailingWhitespace": true
+			}
+    }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/universal:2", // Default Image
   "customizations": {
     "vscode": {
+      // VS Code Extensions to be installed while the machine is being setup
       "extensions": [
         // Java Extension Pack
         "vscjava.vscode-java-pack",
@@ -11,31 +12,34 @@
         "arzg.eclipse",
         "solrike.eclipse-theme-by-solrike"
       ],
+      // Workspace settings (can be customised by the user afterwards too)
       "settings": {
-        "workbench.iconTheme": "eclipse-theme-by-solrike",
-        "workbench.colorTheme": "Eclipse Light",
-        "editor.bracketPairColorization.enabled": true,
-        "editor.experimental.StikyScroll.enabled": true,
-        "editor.minimap.scale": 2,
-        "editor.indentSize": "tabSize",
-        "editor.tabSize": 4,
-        "editor.renderWhitespace": "all",
-        "files.trimTrailingWhitespace": true
+        "workbench.iconTheme": "eclipse-theme-by-solrike", // Eclipse Icon style
+        "workbench.colorTheme": "Eclipse Light",           // Eclipse-styled app
+        "editor.bracketPairColorization.enabled": true,    // Colors each bracket pair
+        "editor.experimental.StikyScroll.enabled": true,   // To stick all the functions, classes at the top
+        "editor.minimap.scale": 2,                         // Mini Map
+        "editor.indentSize": "tabSize",                    // Tab Indent
+        "editor.tabSize": 4,                               // Tab Size of 4
+        "editor.renderWhitespace": "all",                  // Shows the whitespaces
+        "files.trimTrailingWhitespace": true               // Removes any trailing whitespaces at the end
       }
     },
     "codespaces": {
+      // Opens the Java file after the Codespace is built
       "openFiles": [
-        "src/HelloWorld.java"
+        "src/HelloWorld.java" // Opens up the Java file
       ]
     }
   },
+  // Features for installing the Java Environment
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "latest",
-      "jdkDistro": "oracle",
-      "installGradle": true,
-      "installMaven": true,
-      "installAnt": true
+      "version": "latest",   // Latest version of Java
+      "jdkDistro": "oracle", // Installs the Oracle Distribution of Java Development Kit (JDK)
+      "installGradle": true, // Installs Gradle
+      "installMaven": true,  // Installs Maven
+      "installAnt": true     // Installs Ant
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,5 @@
 {
   "image": "mcr.microsoft.com/devcontainers/universal:2",
-  "features": {
-    "ghcr.io/devcontainers/features/java:1": {
-      "version": "latest",
-      "jdkDistro": "oracle",
-      "installGradle": true,
-      "installMaven": true,
-      "installAnt": true
-    }
-  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -34,6 +25,15 @@
       "openFiles": [
         "src/HelloWorld.java"
       ]
+    }
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "latest",
+      "jdkDistro": "oracle",
+      "installGradle": true,
+      "installMaven": true,
+      "installAnt": true
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
         "solrike.eclipse-theme-by-solrike"
       ],
       "settings": {
-        "workbench.iconTheme": "eclipse-theme-by-solrike",
+        "workbench.iconTheme": "eclipse-file-icons-by-solrike",
+        "workbench.colorTheme": "Eclipse Light by Solrike",
         "editor.bracketPairColorization.enabled": true,
         "editor.experimental.StikyScroll.enabled": true,
         "editor.minimap.scale": 2,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,5 +29,6 @@
       "installMaven": true,  // Installs Maven
       "installAnt": true     // Installs Ant
     }
-  }
+  },
+  "postCreateCommand": "sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2", // Default Image
+  "name": "F27SA Codespace",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -14,20 +14,18 @@
       ]
     },
     "codespaces": {
-      // Opens the Java file after the Codespace is built
       "openFiles": [
-        "src/HelloWorld.java" // Opens up the Java file
+        "src/HelloWorld.java"
       ]
     }
   },
-  // Features for installing the Java Environment
   "features": {
     "ghcr.io/devcontainers/features/java:1": {
-      "version": "latest",   // Latest version of Java
-      "jdkDistro": "oracle", // Installs the Oracle Distribution of Java Development Kit (JDK)
-      "installGradle": true, // Installs Gradle
-      "installMaven": true,  // Installs Maven
-      "installAnt": true     // Installs Ant
+      "version": "latest",
+      "jdkDistro": "oracle",
+      "installGradle": true,
+      "installMaven": true,
+      "installAnt": true
     }
   },
   "postCreateCommand": "sudo cp .devcontainer/welcome.txt /usr/local/etc/vscode-dev-containers/first-run-notice.txt"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,12 +7,13 @@
         "vscjava.vscode-java-pack",
         // Miscellaneous Extensions
         "VisualStudioExptTeam.vscodeintellicode",
-        // Eclipse-styled theme
+        // Eclipse-styled themes
+        "arzg.eclipse",
         "solrike.eclipse-theme-by-solrike"
       ],
       "settings": {
-        "workbench.iconTheme": "eclipse-file-icons-by-solrike",
-        "workbench.colorTheme": "Eclipse Light by Solrike",
+        "workbench.iconTheme": "eclipse-theme-by-solrike",
+        "workbench.colorTheme": "Eclipse Light",
         "editor.bracketPairColorization.enabled": true,
         "editor.experimental.StikyScroll.enabled": true,
         "editor.minimap.scale": 2,

--- a/.devcontainer/welcome.txt
+++ b/.devcontainer/welcome.txt
@@ -1,0 +1,8 @@
+Welcome to F27SA Lab 1! 💻
+
+Here you will run your first exercise, printing "Hello World!"
+
+To get started, head over to the src folder, click on HelloWorld.java
+and run the program!
+
+Happy Coding :)

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+    "recommendations": [
+        // Java Extension Pack
+        "vscjava.vscode-java-pack",
+        // Miscellaneous Extensions
+        "VisualStudioExptTeam.vscodeintellicode",
+        // Eclipse-styled themes
+        "arzg.eclipse",
+        "solrike.eclipse-theme-by-solrike",
+        "eamodio.gitlens"
+      ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+		"workbench.iconTheme": "eclipse-theme-by-solrike",
+		"workbench.colorTheme": "Eclipse Dark",
+		"editor.bracketPairColorization.enabled": true,
+		"editor.stickyScroll.enabled": true,
+		"editor.minimap.scale": 2,
+		"editor.insertSpaces": false,
+		"editor.indentSize": "tabSize",
+		"editor.tabSize": 4,
+		"editor.detectIndentation": true,
+		"editor.renderWhitespace": "all",
+		"files.trimTrailingWhitespace": true
+	}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# F27SA Lab 1
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/HWU-F27SA-Java/Lab01_exercises/)


### PR DESCRIPTION
This PR sets up the Java Environment using [GitHub Codespaces](https://github.com/features/codespaces), which sets up a proper developer environment for the students which spins up in less than a minute.
This also enables them to directly code on their browser, regardless of their device specifications.

It also sets up a similar looking theme as to how it is on Eclipse, giving a more familiar look.

Key highlights in the `devcontainer.json` file:
- Installs latest version of Java with the Oracle version of JDK
- Installs the other Java tools i.e. Gradle, Maven, Ant
- [VS Code extension pack for Java](https://marketplace.visualstudio.com/items?itemName=vscjava.vscode-java-pack) (syntax highlighting, error checking, running, debugging, etc.)
- Opening the file directly

Feel free to add any changes that you feel are required.
This will definitely be a great way for students to focus on the coding part directly, rather than the other issues with the setup.